### PR TITLE
adds rotating logs support

### DIFF
--- a/lib/LogFileAccessor.php
+++ b/lib/LogFileAccessor.php
@@ -62,8 +62,27 @@ class LogFileAccessor
                 $args['filesystem'] = new Filesystem(new SftpAdapter($config));
                 break;
             case 'local':
-                $args['filesystem'] = new Filesystem(new Local(dirname($args['path'])));
-                $args['path'] = basename($args['path']);
+                if($args['filePattern']){
+                    date_default_timezone_set('Europe/Madrid'); //change to your timezone
+                    $directory = dirname($args['filePattern']).DIRECTORY_SEPARATOR;
+                    $files = scandir($directory);
+                    $files = array_diff($files, array('.', '..'));
+                    foreach($files as $file) {
+
+                        if(!preg_match(basename($args['path'], $file) && !is_dir($directory . $file))){
+
+                            $time["$file"] = filemtime($directory . $file);
+                        }
+                    }
+                    array_multisort($time);
+                    end($time);
+                    $first_key = key($time);
+                    $args['filesystem'] = new Filesystem(new Local($directory));
+                    $args['path'] =$first_key;
+                }else{
+                    $args['filesystem'] = new Filesystem(new Local(dirname($args['path'])));
+                    $args['path'] = basename($args['path']);
+                }
                 break;
             default:
                 throw new \InvalidArgumentException('Invalid log file type: "'.$args['type'].'"');


### PR DESCRIPTION
Under local log configuration, you can enter a filePattern entry wich contains a regular expresion to the file. For example /var/log/myservice*.log . This allow us to take the newest file of this directory that match with this expression.